### PR TITLE
Fix license and readme file paths in the setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,12 +3,12 @@ name = lightspark
 url = https://www.lightspark.com/
 version = attr: lightspark.version.__version__
 description = Python SDK for the Lightspark API
-long_description = file: README.rst
+long_description = file: README.md
 long_description_content_type = text/markdown
 author = Lightspark Group, Inc.
 author_email = info@lightspark.com
 license = Apache-2.0
-license_files = LICENSE.rst
+license_files = LICENSE
 project_urls =
   Documentation = https://docs.lightspark.com/lightspark-sdk/getting-started?language=Python
   Source Code = https://github.com/lightsparkdev/python-sdk


### PR DESCRIPTION
It seems like these files aren't getting parse correctly by pypi or fossa without the paths being correct here.