### PR TITLE
Update RemoteSigningWebhookEventHandler __repr__

### DIFF
--- a/lightspark/__tests__/test_remote_signing.py
+++ b/lightspark/__tests__/test_remote_signing.py
@@ -1,0 +1,19 @@
+# Copyright ©, 2026-present, Lightspark Group, Inc. - All Rights Reserved
+
+from lightspark import (
+    LightsparkSyncClient,
+    PositiveValidator,
+    RemoteSigningWebhookEventHandler,
+)
+
+
+class TestRemoteSigning:
+    def test_master_seed_not_in_repr(self) -> None:
+        client = LightsparkSyncClient("", "")
+        handler = RemoteSigningWebhookEventHandler(
+            client=client,
+            master_seed=b"1234",
+            validator=PositiveValidator(),
+        )
+
+        assert "1234" not in repr(handler)

--- a/lightspark/remote_signing.py
+++ b/lightspark/remote_signing.py
@@ -1,5 +1,5 @@
 from typing import Any
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 import lightspark_crypto as lsc
 import lightspark
@@ -14,21 +14,14 @@ class PositiveValidator(lsc.Validation):
 @dataclass
 class RemoteSigningWebhookEventHandler:
     client: lightspark.LightsparkSyncClient
-    master_seed: bytes
+    master_seed: bytes = field(repr=False)
     validator: lsc.Validation
 
-    def __init__(
-        self,
-        client: lightspark.LightsparkSyncClient,
-        master_seed: bytes,
-        validator: lsc.Validation,
-    ):
-        self.client = client
-        self.master_seed = master_seed
-        self.validator = validator
-
     def handle_remote_signing_webhook_request(
-        self, data: bytes, hexdigest: str, webhook_secret: str
+        self,
+        data: bytes,
+        hexdigest: str,
+        webhook_secret: str,
     ):
         response = lsc.handle_remote_signing_webhook_event(
             data, hexdigest, webhook_secret, self.master_seed, self.validator


### PR DESCRIPTION
We shouldn't include the `master_seed` in the generated `__repr__` for `RemoteSigningWebhookEventHandler`, since folks probably aren't expecting it to be logged if they include their `RemoteSigningWebhookEventHandler` in a log.