### PR TITLE
Fix release build step broken by the uv migration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,6 @@ jobs:
         with:
           version: "0.11.2"
       - name: "Build dist"
-        run: "uv run --frozen python setup.py sdist --format=zip"
+        run: "uv build"
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
setup.py was deleted in #70 but the release workflow still runs `uv run --frozen python setup.py sdist`, so the next release would fail at the build step. The v2.10.2 release already failed to publish (its workflow run predates #70 and died in the old pipenv setup), which is why PyPI is still at 2.10.1. `uv build` produces the sdist and wheel from pyproject.toml directly, and `gh-action-pypi-publish` picks them up from `dist/` as before.

Tested by running `uv build` in this branch: both artifacts build, and the wheel's `lightspark_client.py` compiles with no SyntaxWarning (the E614_REGEX escape fix from #47 is included, which 2.10.1 on PyPI predates).